### PR TITLE
add build_depend of message_generation for genjava

### DIFF
--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -32,6 +32,7 @@
   <build_depend>rtmbuild</build_depend>
   <build_depend>unzip</build_depend>
   <build_depend>gnuplot</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <run_depend>gnuplot</run_depend>
   <run_depend>moveit_commander</run_depend>


### PR DESCRIPTION
If we installed `ros-kinetic-genjava`, the same probjem of this issue https://github.com/start-jsk/rtmros_common/issues/878 is occurred.

So I send PR like this https://github.com/start-jsk/rtmros_common/pull/907/files to solve the problem.